### PR TITLE
Feature/puente al exito

### DIFF
--- a/app/views/prequalifications/prequalificationDetailsAnalysis.html
+++ b/app/views/prequalifications/prequalificationDetailsAnalysis.html
@@ -131,7 +131,7 @@
                         </div>
 
                         <!-- Comentario de excepciones-->
-                        <div class="form-group">
+                        <div class="form-group" ng-if="groupData.prequalificationType.value=='PAE'">
                             <label>{{'label.input.addexceptioncomments' | translate}}</label>
                             <textarea rows="3" class="form-control" name="exceptionComment"
                                       placeholder="{{'label.input.addexceptioncomments' | translate}}"
@@ -141,7 +141,7 @@
 
                         <!-- Botón para enviar el comentario -->
                         <div class="text-right"
-                             ng-if="formData.exceptionComment && formData.exceptionComment.trim() !== ''">
+                             ng-if="formData.exceptionComment && formData.exceptionComment.trim() !== '' && groupData.prequalificationType.value=='PAE'">
                             <button class="btn btn-success" ng-click="submitExceptionComment()">
                                 <i class="fa fa-comment"></i> {{'label.anchor.save' | translate}}
                             </button>


### PR DESCRIPTION
## 
This pull request makes a targeted UI change to the prequalification details analysis view. Now, the exception comment field and its submit button are only displayed if the prequalification type is 'PAE', improving the conditional logic and user experience.

UI logic improvements:

* The exception comment input field (`textarea`) is now only shown when `groupData.prequalificationType.value` is `'PAE'`, ensuring that this field appears only for relevant prequalification types.
* The submit button for the exception comment is also restricted to display only when the prequalification type is `'PAE'` and the comment is not empty, further refining the form's conditional behavior.