### PR TITLE
Feature/puente al exito

### DIFF
--- a/app/views/organization/editcommittee.html
+++ b/app/views/organization/editcommittee.html
@@ -75,7 +75,7 @@
 								<hr/>
 								<div class="row">
 									<div class="col-sm-4">
-										<input type="number" class="form-control" placeholder="{{'label.input.from'|translate}}" ng-model="belowLimitInput.from" ng-disabled="belowLimitInput.from > 0" />
+										<input type="number" class="form-control" placeholder="{{'label.input.from'|translate}}" ng-model="belowLimitInput.from" ng-disabled="belowExceptionLimits.length>0" />
 									</div>
 									<div class="col-sm-4">
 										<input type="number" class="form-control" placeholder="{{'label.input.to'|translate}}" ng-model="belowLimitInput.to" />
@@ -84,7 +84,7 @@
 										<button type="button" class="btn btn-success" ng-click="addBelowLimit()"><i class="fa fa-plus"></i></button>
 									</div>
 								</div>
-								<div class="row" style="margin-top:10px;" ng-if="belowExceptionLimits.length">
+								<div class="row" style="margin-top:10px;" ng-if="belowExceptionLimits.length>0">
 									<div class="col-sm-12">
 										<table class="table table-bordered table-condensed">
 											<thead>
@@ -113,7 +113,7 @@
 								<hr/>
 								<div class="row">
 									<div class="col-sm-4">
-										<input type="number" class="form-control" placeholder="{{'label.input.from'|translate}}" ng-model="aboveLimitInput.from" ng-disabled="aboveLimitInput.from > 0" />
+										<input type="number" class="form-control" placeholder="{{'label.input.from'|translate}}" ng-model="aboveLimitInput.from" ng-disabled="aboveExceptionLimits.length>0" />
 									</div>
 									<div class="col-sm-4">
 										<input type="number" class="form-control" placeholder="{{'label.input.to'|translate}}" ng-model="aboveLimitInput.to" />
@@ -122,7 +122,7 @@
 										<button type="button" class="btn btn-success" ng-click="addAboveLimit()"><i class="fa fa-plus"></i></button>
 									</div>
 								</div>
-								<div class="row" style="margin-top:10px;" ng-if="aboveExceptionLimits.length">
+								<div class="row" style="margin-top:10px;" ng-if="aboveExceptionLimits.length>0">
 									<div class="col-sm-12">
 										<table class="table table-bordered table-condensed">
 											<thead>

--- a/app/views/prequalifications/prequalificationDetailsAnalysis.html
+++ b/app/views/prequalifications/prequalificationDetailsAnalysis.html
@@ -433,15 +433,15 @@
                         <!-- ANAYLSIS APPROVAL A-B-C-D -->
 
                         <!-- SEND TO ANALYSIS UNIT AGENCY VIEW-->
-                        <button ng-if="prequalificationType ==='analysis'"
-                                ng-click="processAnalysisRequest('approveCommittee','label.button.prequalification.sendtoCommitteeWithoutException')"
+                        <button ng-if="prequalificationType ==='analysis' && groupData.prequalificationType.value=='PAE'"
+                                ng-click="processAnalysisRequest('approvecommitee','label.button.prequalification.sendtoCommitteeWithoutException')"
                                 type="button"
                                 class="btn btn-primary" has-permission='PROCESSANALYSIS_PREQUALIFICATIONS'>
                             {{'label.button.prequalification.sendtoCommitteeWithoutException' | translate}}
                         </button>
 
                         <!-- SEND QUEUE EXCEPTION AGENCY VIEW-->
-                        <button ng-if="prequalificationType ==='analysis'"
+                        <button ng-if="prequalificationType ==='analysis' && groupData.prequalificationType.value=='PAE'"
                                 ng-click="processAnalysisRequest('approvecommiteeWhitExc','label.button.prequalification.sendtoexception')"
                                 type="button"
                                 class="btn btn-primary" has-permission='PROCESSANALYSIS_PREQUALIFICATIONS'>
@@ -460,7 +460,7 @@
 
                         <!-- RENEGOTIATION-->
 
-                        <button ng-if="prequalificationType ==='committeeapprovals'"
+                        <button ng-if="prequalificationType ==='committeeapprovals' && groupData.prequalificationType.value=='PAE'"
                                 ng-click="processAnalysisRenegotiation('sendToRenegotiation','label.button.sendRenegotiation')"
                                 type="button"
                                 class="btn btn-default" has-permission='PROCESSANALYSIS_PREQUALIFICATIONS'>
@@ -473,7 +473,12 @@
                     <!-- BUTTONS RIGHT APPROVE ONLY commiteepprovals and reject all parts-->
                     <div class="text-right m-1 ms-auto">
 
-                        <button ng-if="prequalificationType !=='renegotiations'" ng-click="rejectPrequalification()"
+                        <button ng-if="prequalificationType !=='renegotiations' &&  groupData.prequalificationType.value=='PAE'" ng-click="rejectPrequalification()"
+                                type="button" class="btn btn-danger" has-permission='PROCESSANALYSIS_PREQUALIFICATIONS'>
+                            {{'label.button.reject' | translate}}
+                        </button>
+
+                        <button ng-if="groupData.prequalificationType.value!='PAE'" ng-click="processAnalysisRequest('reject' ,'label.button.reject')"
                                 type="button" class="btn btn-danger" has-permission='PROCESSANALYSIS_PREQUALIFICATIONS'>
                             {{'label.button.reject' | translate}}
                         </button>
@@ -485,6 +490,13 @@
 
                         <button ng-if="prequalificationType ==='committeeapprovals'"
                                 ng-click="processAnalysisRequest('approveCommittee','label.button.approve')"
+                                type="button"
+                                class="btn btn-primary" has-permission='PROCESSANALYSIS_PREQUALIFICATIONS'>
+                            {{'label.button.approve' | translate}}
+                        </button>
+
+                        <button ng-if="prequalificationType ==='analysis' && groupData.prequalificationType.value!='PAE'"
+                                ng-click="processAnalysisRequest('approveanalysis','label.button.approve')"
                                 type="button"
                                 class="btn btn-primary" has-permission='PROCESSANALYSIS_PREQUALIFICATIONS'>
                             {{'label.button.approve' | translate}}


### PR DESCRIPTION
## 
This pull request updates the logic for enabling/disabling form fields and displaying action buttons in the committee and prequalification analysis views. The main focus is to ensure that form controls and buttons are only active or visible under the correct conditions, especially based on the type of prequalification process (`PAE` or not). This improves user experience by preventing invalid actions and clarifying available options.

**Form control logic improvements:**

* The "from" input fields for both "Below Exception Limits" and "Above Exception Limits" sections in `editcommittee.html` are now disabled if there is at least one exception limit already present, rather than only when the value is greater than zero. [[1]](diffhunk://#diff-d34b59db9239c94722440de53f626a4397711d2b5033be501c465f9c81f6da8bL78-R78) [[2]](diffhunk://#diff-d34b59db9239c94722440de53f626a4397711d2b5033be501c465f9c81f6da8bL116-R116)
* The display of exception limit tables is now explicitly tied to whether there are any exception limits (`length > 0`), making the condition clearer and more robust. [[1]](diffhunk://#diff-d34b59db9239c94722440de53f626a4397711d2b5033be501c465f9c81f6da8bL87-R87) [[2]](diffhunk://#diff-d34b59db9239c94722440de53f626a4397711d2b5033be501c465f9c81f6da8bL125-R125)

**Button visibility and action logic enhancements:**

* In `prequalificationDetailsAnalysis.html`, several action buttons (such as "Send to Committee Without Exception," "Send to Exception," "Send to Renegotiation," and "Reject") are now only shown when the `groupData.prequalificationType.value` is `'PAE'`, ensuring that these actions are only available for the appropriate prequalification type. [[1]](diffhunk://#diff-07fd2ea7954285e7b1037a2a44b4d51dc39862ced7842b14b51c0844109026b4L436-R444) [[2]](diffhunk://#diff-07fd2ea7954285e7b1037a2a44b4d51dc39862ced7842b14b51c0844109026b4L463-R463) [[3]](diffhunk://#diff-07fd2ea7954285e7b1037a2a44b4d51dc39862ced7842b14b51c0844109026b4L476-R481)
* For cases where the prequalification type is not `'PAE'`, a separate "Reject" button and a new "Approve" button are provided, with logic to call the correct handler functions. This clarifies the workflow for non-PAE types. [[1]](diffhunk://#diff-07fd2ea7954285e7b1037a2a44b4d51dc39862ced7842b14b51c0844109026b4L476-R481) [[2]](diffhunk://#diff-07fd2ea7954285e7b1037a2a44b4d51dc39862ced7842b14b51c0844109026b4R498-R504)