### PR TITLE
Feature/puente al exito

### DIFF
--- a/app/global-translations/locale-en.json
+++ b/app/global-translations/locale-en.json
@@ -5073,6 +5073,8 @@
   "label.heading.deposit.guarantee.amount": "To Deposit Amount",
   "label.heading.deposit.number": "Deposit No.",
   "label.heading.select.bank.account": "Please select a bank account ...",
+  "label.heading.warantydocuments": "Warranty Documents",
+  "label.heading.guarantyevaluation": "Guarantee Evaluation",
   "label.anchor.managecommittes": "Manage Committees",
   "label.addnewcommitteeormodifycommittee": "Add new or modify committee",
   "label.heading.committeeeUsers": "Number of users",

--- a/app/global-translations/locale-es.json
+++ b/app/global-translations/locale-es.json
@@ -4703,6 +4703,8 @@
 	"label.button.assign": "Asignar",
 	"label.heading.assign.cheques.to.loans": "Asignar cheques de préstamo",
 	"label.heading.select.bank.account": "Por favor seleccione una cuenta bancaria ...",
+	"label.heading.warantydocuments": "Documentos de garantía",
+	"label.heading.guarantyevaluation": "Evaluación de garantía",
 	"label.anchor.managecommittes": "Administrar comités",
 	"label.addnewcommitteeormodifycommittee": "Agregar nuevo comité o modificar comité existente",
 	"label.heading.committeeeUsers": "Nro. de usuarios",

--- a/app/scripts/controllers/loanAccount/NewLoanAccAppController.js
+++ b/app/scripts/controllers/loanAccount/NewLoanAccAppController.js
@@ -31,6 +31,9 @@
             scope.currentLoanData = {};
             scope.currentLoanDocs = {}
             scope.loanDocuments = [];
+            scope.guarantyFiles = [];
+            scope.paeRequiredGuaranteeOptions;
+            scope.requiresGuaranteeDocuments = false;
             scope.product;
             scope.clientHousingType;
             scope.formData.totalExternalLoanAmount =0;
@@ -230,6 +233,7 @@
                     scope.datatables = data.datatables;
                     scope.handleDatatables(scope.datatables);
                     scope.disabled = false;
+                    scope.paeRequiredGuaranteeOptions = data.paeRequiredGuaranteeOptions;
                 });
 
                 resourceFactory.loanResource.get({
@@ -963,6 +967,43 @@
                 scope.formData.businessProfit=0;
                 scope.formData.businessProfit=Number(sales?sales:0) - Number(purchases?purchases:0);
                 return scope.formData.businessProfit;
+            }
+            scope.updateRequiredPrequalificationCount = function (index) {
+                let count = 0;
+                if (scope.paeRequiredGuaranteeOptions[index].selected){
+                    scope.paeRequiredGuaranteeOptions[index].quantity=1;
+                }else{
+                    scope.paeRequiredGuaranteeOptions[index].quantity=0;
+                }
+                for (doc in scope.paeRequiredGuaranteeOptions){
+                    if (doc.selected){
+                        console.log("updated required docs to true")
+                        scope.requiresGuaranteeDocuments=true;
+                        break;
+                    }
+                }
+            }
+
+            scope.onGuarantyFileSelect = function($files, parentIndex, finalIndex){
+                console.log("File selected for guaranty document upload:", parentIndex, finalIndex);
+                // Ensure the array exists
+                if (!scope.paeRequiredGuaranteeOptions[parentIndex].documents) {
+                    scope.paeRequiredGuaranteeOptions[parentIndex].documents = [];
+                }
+                // Store the file(s) at the correct index
+                scope.paeRequiredGuaranteeOptions[parentIndex].documents[finalIndex] = $files[0];
+            }
+
+            scope.requiresGuaranteeDocs = function () {
+                let requiresGuaranteeDocs = false;
+                for (let i=0; i<scope.paeRequiredGuaranteeOptions.length; i++){
+                    let guaranteeOption = scope.paeRequiredGuaranteeOptions[i];
+                    if (guaranteeOption.selected){
+                        requiresGuaranteeDocs = true;
+                        break;
+                    }
+                }
+                scope.requiresGuaranteeDocuments =  requiresGuaranteeDocs;
             }
         }
     });

--- a/app/views/loans/newloanaccount.html
+++ b/app/views/loans/newloanaccount.html
@@ -611,7 +611,7 @@
                                 </label>
                                 <label data-ng-show="loanaccountinfo.interestRecalculationData.recalculationRestFrequencyType.id == 3 &&
                                             loanaccountinfo.interestRecalculationData.recalculationRestFrequencyWeekday != null">
-                                    {{label.heading.on}}
+                                    {{'label.heading.on' | translate}}
                                     {{ loanaccountinfo.interestRecalculationData.recalculationRestFrequencyWeekday.value}}
                                 </label>
                                 <label data-ng-show="loanaccountinfo.interestRecalculationData.recalculationRestFrequencyType.id == 4 &&
@@ -987,6 +987,73 @@
                     </div>
                     <br>
                     <hr>
+                    <button class="btn btn-default pull-left" wz-previous>
+                        <i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Previous
+                    </button>
+                    <button class="btn btn-default pull-right" type="submit">Next&nbsp;&nbsp;
+                        <i class="fa fa-arrow-right"></i>
+                    </button>
+                </fieldset>
+            </form>
+        </wz-step>
+<!--WARRANTY DOCUMENTS TAB-->
+        <wz-step wz-title="{{ 'label.heading.guarantyevaluation' | translate }}" wz-disabled="{{!paeRequiredGuaranteeOptions}}">
+            <form name="WarantyDocuments" novalidate="" ng-submit="goNext(WarantyDocuments)">
+                <fieldset>
+                    <api-validate></api-validate>
+                    <!--<h3>{{'label.heading.charges' | translate}}</h3>-->
+                    <hr>
+                    <table class="table table-bordered table-striped" style="width:50%; table-layout: fixed">
+                        <tbody>
+                        <tr ng-repeat="docOption in paeRequiredGuaranteeOptions">
+                            <td>
+                                <label>
+                                    <input type="checkbox" ng-model="paeRequiredGuaranteeOptions[$index].selected" ng-change="updateRequiredPrequalificationCount($index)"/>
+                                    {{docOption.name}}
+                                </label>
+                            </td>
+                            <td>
+                                <input id="count" ng-if="paeRequiredGuaranteeOptions[$index].selected" type="number" name="count"
+                                       ng-model="paeRequiredGuaranteeOptions[$index].quantity"
+                                       class="form-control" late-Validate/>
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                    <hr>
+                    <button class="btn btn-default pull-left" wz-previous>
+                        <i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Previous
+                    </button>
+                    <button class="btn btn-default pull-right" type="submit">Next&nbsp;&nbsp;
+                        <i class="fa fa-arrow-right"></i>
+                    </button>
+                </fieldset>
+            </form>
+        </wz-step>
+
+        <wz-step wz-title="{{ 'label.heading.warantydocuments' | translate }}" wz-disabled="{{!paeRequiredGuaranteeOptions}}">
+            <form name="GuarantyDocuments" ng-submit="goNext(GuarantyDocuments)" class="form-horizontal">
+                <fieldset>
+                    <api-validate></api-validate>
+                    <br>
+                    <div class="row" ng-repeat="requiredDoc in paeRequiredGuaranteeOptions" ng-if="requiredDoc.selected">
+                        <div class="col-sm-6 alert alert-default">
+                            <div class="form-horizontal">
+                                <div class="form-group">
+                                    <label class="control-label col-sm-4" for="name">{{requiredDoc.name}}<span class="required">*</span></label>
+
+                                    <div class="col-sm-6">
+                                        <div ng-repeat="n in [].constructor(requiredDoc.quantity) track by $index" style="margin-top: 10px;">
+                                            <input id="grFile{{$parent.$index}}_{{$index}}" type="file" ng-model="guarantyFiles[$parent.$index][$index]"
+                                                   ngf-select="onGuarantyFileSelect($files, $parent.$index, $index)" required late-validate>
+                                            <form-validate valattributeform="GuarantyDocuments" valattribute="grFile{{$parent.$index}}_{{$index}}"/>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <br>
                     <button class="btn btn-default pull-left" wz-previous>
                         <i class="fa fa-arrow-left"></i>&nbsp;&nbsp;Previous
                     </button>
@@ -2759,4 +2826,4 @@
     </script>
 
 </div>
-</div>
+


### PR DESCRIPTION
## 
This pull request introduces a new feature to handle guarantee (warranty) documents in the loan application process. It adds new UI steps for selecting required guarantee documents, specifying their quantities, and uploading the corresponding files. The implementation includes updates to both the frontend logic and translations for English and Spanish.

**New Guarantee Document Workflow:**

* Added two new steps to the loan application wizard in `newloanaccount.html` for guarantee evaluation and document upload. These steps allow users to select required guarantee documents, specify quantities, and upload files for each selected document.

* Implemented controller logic in `NewLoanAccAppController.js` to manage guarantee document options, handle file selections, and track whether guarantee documents are required. This includes new scope variables and functions such as `guarantyFiles`, `paeRequiredGuaranteeOptions`, `updateRequiredPrequalificationCount`, `onGuarantyFileSelect`, and `requiresGuaranteeDocs`. [[1]](diffhunk://#diff-a69f535dc9297bc4f925f880ad6a2cf09d601ee5fbd74c638e899ea4b4f102e5R34-R36) [[2]](diffhunk://#diff-a69f535dc9297bc4f925f880ad6a2cf09d601ee5fbd74c638e899ea4b4f102e5R236) [[3]](diffhunk://#diff-a69f535dc9297bc4f925f880ad6a2cf09d601ee5fbd74c638e899ea4b4f102e5R971-R1007)

**Translation Updates:**

* Added English and Spanish translations for the new guarantee document-related labels: "Warranty Documents" and "Guarantee Evaluation". [[1]](diffhunk://#diff-c65161937ad8cbaa904f94173bd6ff63a781af30b2c7d7eceec188cf68fc910bR5076-R5077) [[2]](diffhunk://#diff-12520c21a012de0a0b2b44c107bc6877c644357cacd7b53d2e6ebe24544fd3ebR4706-R4707)

**Minor Improvements:**

* Fixed a missing translation pipe for the "on" label in the interest recalculation section of the loan application view.

* Minor formatting adjustment at the end of `newloanaccount.html`.